### PR TITLE
refactor: improve 2 behaviors, simplify 1 function

### DIFF
--- a/pkg/qseal/retrieve-private-keys.go
+++ b/pkg/qseal/retrieve-private-keys.go
@@ -17,7 +17,7 @@ const labelSelector = "sealedsecrets.bitnami.com/sealed-secrets-key"
 func (k *KubeSealClient) RetrievePrivateKeys() (map[string]*rsa.PrivateKey, error) {
 	clientset, err := k.getClientSet()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create clientset: %v", err)
+		return nil, fmt.Errorf("failed to create clientset: %w", err)
 	}
 
 	secrets, err := clientset.CoreV1().

--- a/pkg/qseal/retrieve-private-keys.go
+++ b/pkg/qseal/retrieve-private-keys.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rsa"
 	"fmt"
-	"log"
 
 	"github.com/bitnami-labs/sealed-secrets/pkg/crypto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,7 +17,7 @@ const labelSelector = "sealedsecrets.bitnami.com/sealed-secrets-key"
 func (k *KubeSealClient) RetrievePrivateKeys() (map[string]*rsa.PrivateKey, error) {
 	clientset, err := k.getClientSet()
 	if err != nil {
-		log.Fatalf("Failed to create clientset: %v", err)
+		return nil, fmt.Errorf("failed to create clientset: %v", err)
 	}
 
 	secrets, err := clientset.CoreV1().

--- a/pkg/qseal/seal-all.go
+++ b/pkg/qseal/seal-all.go
@@ -24,7 +24,7 @@ func SealAll(qsealRc qsealrc.Qsealrc) error {
 			// we clear the file
 			err = os.WriteFile(sealedPath, []byte{}, 0644)
 			if err != nil {
-				return fmt.Errorf("error clearing file %s: %v", sealedPath, err)
+				return fmt.Errorf("error clearing file %s: %w", sealedPath, err)
 			}
 			sealedPaths[sealedPath] = true
 		}

--- a/pkg/qseal/seal.go
+++ b/pkg/qseal/seal.go
@@ -64,7 +64,7 @@ func (k *KubeSealClient) Seal(secret qsealrc.Secret) error {
 	// we update the date of the files
 	err = secret.SyncFileTime()
 	if err != nil {
-		return fmt.Errorf("error updating the date of the secrets %s: %v", sealedPath, err)
+		return fmt.Errorf("error updating the date of the secrets %s: %w", sealedPath, err)
 	}
 	return nil
 }

--- a/pkg/qseal/status.go
+++ b/pkg/qseal/status.go
@@ -28,7 +28,7 @@ const timeFormat = "2006-01-02 15:04:05"
 func Status(qsealRc qsealrc.Qsealrc) error {
 	secretsBySealedPath, actionBySealedPath, err := getSecretsStatus(qsealRc)
 	if err != nil {
-		return fmt.Errorf("error getting secrets status: %v", err)
+		return fmt.Errorf("error getting secrets status: %w", err)
 	}
 	for sealedPath, secrets := range secretsBySealedPath {
 		logSecretAction(actionBySealedPath[sealedPath], sealedPath, secrets)
@@ -55,11 +55,11 @@ func getSecretsStatus(qsealRc qsealrc.Qsealrc) (map[string][]qsealrc.Secret, map
 	for _, secret := range qsealRc.Secrets {
 		sealedPath, err := secret.SealedPath()
 		if err != nil {
-			return nil, nil, fmt.Errorf("error getting sealed path for secret %s: %v", secret.Name, err)
+			return nil, nil, fmt.Errorf("error getting sealed path for secret %s: %w", secret.Name, err)
 		}
 		action, err := decideSyncAction(sealedPath, secret)
 		if err != nil {
-			return nil, nil, fmt.Errorf("error deciding sync action for secret %s: %v", secret.Name, err)
+			return nil, nil, fmt.Errorf("error deciding sync action for secret %s: %w", secret.Name, err)
 		}
 		existingAction, ok := actionBySealedPath[sealedPath]
 		// is have already a action for this sealed path that is not
@@ -86,7 +86,7 @@ func decideSyncAction(sealedPath string, secret qsealrc.Secret) (SyncAction, err
 		if os.IsNotExist(err) {
 			return SyncActionSeal, nil
 		}
-		return SyncActionDoNothing, fmt.Errorf("error checking file %s: %v", sealedPath, err)
+		return SyncActionDoNothing, fmt.Errorf("error checking file %s: %w", sealedPath, err)
 	}
 	// if we have a env file we gatter the date of the file
 	var sourceFileDate time.Time
@@ -96,7 +96,7 @@ func decideSyncAction(sealedPath string, secret qsealrc.Secret) (SyncAction, err
 			if os.IsNotExist(err) {
 				return SyncActionUnseal, nil
 			}
-			return SyncActionDoNothing, fmt.Errorf("error checking file %s: %v", *secret.Env, err)
+			return SyncActionDoNothing, fmt.Errorf("error checking file %s: %w", *secret.Env, err)
 		}
 	} else {
 		// we check the files and we keep the most recent date
@@ -106,7 +106,7 @@ func decideSyncAction(sealedPath string, secret qsealrc.Secret) (SyncAction, err
 				if os.IsNotExist(err) {
 					return SyncActionUnseal, nil
 				}
-				return SyncActionDoNothing, fmt.Errorf("error checking file %s: %v", file, err)
+				return SyncActionDoNothing, fmt.Errorf("error checking file %s: %w", file, err)
 			}
 			if fileDate.After(sourceFileDate) {
 				sourceFileDate = fileDate

--- a/pkg/qseal/sync.go
+++ b/pkg/qseal/sync.go
@@ -10,15 +10,15 @@ import (
 func Sync(qsealRc qsealrc.Qsealrc) error {
 	secretsBySealedPath, actionBySealedPath, err := getSecretsStatus(qsealRc)
 	if err != nil {
-		return fmt.Errorf("error getting secrets status: %v", err)
+		return fmt.Errorf("error getting secrets status: %w", err)
 	}
 	sealClient, err := NewKubeSealClient(qsealRc)
 	if err != nil {
-		return fmt.Errorf("error creating seal client: %v", err)
+		return fmt.Errorf("error creating seal client: %w", err)
 	}
 	keySet, err := sealClient.RetrievePrivateKeys()
 	if err != nil {
-		return fmt.Errorf("error retrieving private keys: %v", err)
+		return fmt.Errorf("error retrieving private keys: %w", err)
 	}
 	for sealedPath, secrets := range secretsBySealedPath {
 		logSecretAction(actionBySealedPath[sealedPath], sealedPath, secrets)
@@ -26,19 +26,19 @@ func Sync(qsealRc qsealrc.Qsealrc) error {
 		case SyncActionSeal:
 			err = os.WriteFile(sealedPath, []byte{}, 0644)
 			if err != nil {
-				return fmt.Errorf("error clearing file %s: %v", sealedPath, err)
+				return fmt.Errorf("error clearing file %s: %w", sealedPath, err)
 			}
 			for _, secret := range secrets {
 				err = sealClient.Seal(secret)
 				if err != nil {
-					return fmt.Errorf("error sealing secret %s: %v", secret.Name, err)
+					return fmt.Errorf("error sealing secret %s: %w", secret.Name, err)
 				}
 			}
 		case SyncActionUnseal:
 			for _, secret := range secrets {
 				err = sealClient.Unseal(secret, keySet)
 				if err != nil {
-					return fmt.Errorf("error unsealing secret %s: %v", secret.Name, err)
+					return fmt.Errorf("error unsealing secret %s: %w", secret.Name, err)
 				}
 			}
 		case SyncActionDoNothing:

--- a/pkg/qseal/unseal-all.go
+++ b/pkg/qseal/unseal-all.go
@@ -19,7 +19,7 @@ func UnsealAll(qsealRc qsealrc.Qsealrc) error {
 	for _, secret := range qsealRc.Secrets {
 		err := sealClient.Unseal(secret, keySet)
 		if err != nil {
-			return fmt.Errorf("error unsealing secret %s: %v", secret.Name, err)
+			return fmt.Errorf("error unsealing secret %s: %w", secret.Name, err)
 		}
 	}
 	return nil

--- a/pkg/qseal/unseal.go
+++ b/pkg/qseal/unseal.go
@@ -54,7 +54,7 @@ func (*KubeSealClient) Unseal(secret qsealrc.Secret, keySet map[string]*rsa.Priv
 	// this allow us to sync smartly the sealed secret with the source and vice versa
 	err = secret.SyncFileTime()
 	if err != nil {
-		return fmt.Errorf("error updating the date of the secrets %s: %v", sealedPath, err)
+		return fmt.Errorf("error updating the date of the secrets %s: %w", sealedPath, err)
 	}
 	return nil
 }

--- a/pkg/qsealrc/models.go
+++ b/pkg/qsealrc/models.go
@@ -57,13 +57,13 @@ func (secret Secret) SyncFileTime() error {
 	}
 	err = os.Chtimes(sealedPath, now, now)
 	if err != nil {
-		return fmt.Errorf("error updating the date of the sealed secret %s: %v", sealedPath, err)
+		return fmt.Errorf("error updating the date of the sealed secret %s: %w", sealedPath, err)
 	}
 	// we update the date of the env if not nil
 	if secret.Env != nil {
 		err = os.Chtimes(*secret.Env, now, now)
 		if err != nil {
-			return fmt.Errorf("error updating the date of the env %s: %v", *secret.Env, err)
+			return fmt.Errorf("error updating the date of the env %s: %w", *secret.Env, err)
 		}
 		return nil
 	}
@@ -71,7 +71,7 @@ func (secret Secret) SyncFileTime() error {
 	for _, file := range secret.Files {
 		err = os.Chtimes(file, now, now)
 		if err != nil {
-			return fmt.Errorf("error updating the date of the file %s: %v", file, err)
+			return fmt.Errorf("error updating the date of the file %s: %w", file, err)
 		}
 	}
 	return nil

--- a/pkg/qsealrc/models.go
+++ b/pkg/qsealrc/models.go
@@ -30,15 +30,8 @@ type Secret struct {
 }
 
 func (s Secret) Validate() error {
-	optionThere := false
-	if s.Env != nil {
-		optionThere = true
-	}
-	if len(s.Files) > 0 {
-		if optionThere {
-			return fmt.Errorf("you can only use one of env or files for qseal secret %s", s.Name)
-		}
-		optionThere = true
+	if s.Env != nil && len(s.Files) > 0 {
+		return fmt.Errorf("you can only use one of env or files for qseal secret %s", s.Name)
 	}
 	return nil
 }

--- a/pkg/secretgen/degenerator.go
+++ b/pkg/secretgen/degenerator.go
@@ -15,7 +15,7 @@ func DeGen(unsealed *corev1.Secret, secret qsealrc.Secret) error {
 		envPath := *secret.Env
 		file, err := os.OpenFile(envPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
-			return fmt.Errorf("failed to open env file %s: %v", envPath, err)
+			return fmt.Errorf("failed to open env file %s: %w", envPath, err)
 		}
 		defer file.Close()
 		writer := io.Writer(file)
@@ -23,7 +23,7 @@ func DeGen(unsealed *corev1.Secret, secret qsealrc.Secret) error {
 			// Write the key-value pair to the env file
 			_, err := fmt.Fprintf(writer, "%s=%s\n", key, value)
 			if err != nil {
-				return fmt.Errorf("failed to write to env file %s: %v", envPath, err)
+				return fmt.Errorf("failed to write to env file %s: %w", envPath, err)
 			}
 		}
 		return nil
@@ -32,7 +32,7 @@ func DeGen(unsealed *corev1.Secret, secret qsealrc.Secret) error {
 	for _, filePath := range secret.Files {
 		file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
-			return fmt.Errorf("failed to open file %s: %v", filePath, err)
+			return fmt.Errorf("failed to open file %s: %w", filePath, err)
 		}
 		defer file.Close()
 		// we keep the file name without the path
@@ -43,7 +43,7 @@ func DeGen(unsealed *corev1.Secret, secret qsealrc.Secret) error {
 		}
 		_, err = file.Write(data)
 		if err != nil {
-			return fmt.Errorf("failed to write to file %s: %v", filePath, err)
+			return fmt.Errorf("failed to write to file %s: %w", filePath, err)
 		}
 	}
 	return nil

--- a/pkg/secretgen/generator.go
+++ b/pkg/secretgen/generator.go
@@ -29,7 +29,7 @@ func Gen(secret qsealrc.Secret) (*kubemodels.Secret, error) {
 		envPath := *secret.Env
 		file, err := os.Open(envPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to open env file %s: %v", envPath, err)
+			return nil, fmt.Errorf("failed to open env file %s: %w", envPath, err)
 		}
 		defer file.Close()
 		reader := io.Reader(file)
@@ -50,7 +50,7 @@ func Gen(secret qsealrc.Secret) (*kubemodels.Secret, error) {
 	for _, filePath := range secret.Files {
 		file, err := os.Open(filePath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to open file %s: %v", filePath, err)
+			return nil, fmt.Errorf("failed to open file %s: %w", filePath, err)
 		}
 		defer file.Close()
 		// we keep the file name without the path


### PR DESCRIPTION
- `Secret.Validate()` was not easy to read, simplified it
- `log.Fatalf()` was used 1 time instead og the usual `return err` from the rest of the code. It hides an exit, so changed it to a simple return
- `fmt.Printf("%v", err)` should use `%w` instead of `%v` to allow error wrapping. This allows error unwrapping. The rendered string will be the same (except for nil, but this case is covered).