### PR TITLE
feat: search qsealrc.yaml in parent directories too

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -22,3 +22,7 @@ var initCmd = &cobra.Command{
 		}
 	},
 }
+
+func init() {
+	initCmd.PersistentFlags().BoolP("ignore-parents", "i", false, "ignore existing qsealrc.yaml files in parent directories")
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -9,7 +9,13 @@ var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize the qseal configuration file",
 	Run: func(cmd *cobra.Command, args []string) {
-		err := qsealrc.Init()
+		ignoreParents, err := cmd.PersistentFlags().GetBool("ignore-parents")
+		if err != nil {
+			cmd.PrintErrln("error reading command arguments:", err)
+			return
+		}
+
+		err = qsealrc.Init(ignoreParents)
 		if err != nil {
 			cmd.PrintErrln("error initializing configuration:", err)
 			return

--- a/cmd/qseal.go
+++ b/cmd/qseal.go
@@ -37,4 +37,6 @@ func init() {
 	RootCmd.AddCommand(unsealAllCmd)
 	RootCmd.AddCommand(syncCmd)
 	RootCmd.AddCommand(statusCmd)
+
+	initCmd.PersistentFlags().BoolP("ignore-parents", "i", false, "ignore existing qsealrc.yaml files in parent directories")
 }

--- a/cmd/qseal.go
+++ b/cmd/qseal.go
@@ -37,6 +37,4 @@ func init() {
 	RootCmd.AddCommand(unsealAllCmd)
 	RootCmd.AddCommand(syncCmd)
 	RootCmd.AddCommand(statusCmd)
-
-	initCmd.PersistentFlags().BoolP("ignore-parents", "i", false, "ignore existing qsealrc.yaml files in parent directories")
 }

--- a/pkg/qsealrc/init.go
+++ b/pkg/qsealrc/init.go
@@ -16,12 +16,21 @@ type HeaderTemplate struct {
 	Date   string
 }
 
-
-func Init() error {
-	// Check if the .qsealrc.yaml file exists
+func Init(ignoreParents bool) error {
+	// Check if the .qsealrc.yaml file exists in current directory
 	_, err := os.Stat(QsealrcFileName)
 	if !os.IsNotExist(err) {
-		return fmt.Errorf("file %s already exists", QsealrcFileName)
+		return fmt.Errorf("file %s already exists in current directory", QsealrcFileName)
+	}
+	// Check if the .qsealrc.yaml file exists in parent directories (unless ignored)
+	if !ignoreParents {
+		dir, found, err := walkDir()
+		if err != nil {
+			return err
+		}
+		if found {
+			return fmt.Errorf("file %s already exists in parent directory %s (use -i to ignore parents)", QsealrcFileName, dir)
+		}
 	}
 	// Create the .qsealrc.yaml file with default values
 	file, err := os.Create(QsealrcFileName)

--- a/pkg/qsealrc/load.go
+++ b/pkg/qsealrc/load.go
@@ -3,17 +3,55 @@ package qsealrc
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/mcuadros/go-defaults"
 	"gopkg.in/yaml.v3"
 )
 
+func walkDir() (dir string, found bool, err error) {
+	dir, err = os.Getwd()
+	if err != nil {
+		return "", false, fmt.Errorf("error reading working directory")
+	}
+
+	for {
+		rcFullpath := filepath.Join(dir, QsealrcFileName)
+		_, err := os.Stat(rcFullpath)
+		if err == nil {
+			found = true
+			break
+		} else {
+			if !os.IsNotExist(err) {
+				return "", false, fmt.Errorf("error searching for %s: %w", QsealrcFileName, err)
+			}
+
+			nextDir := filepath.Dir(dir)
+			if nextDir == dir { // Stop at root dir
+				break
+			}
+			dir = nextDir
+		}
+	}
+
+	return dir, found, nil
+}
+
 func Load() (*Qsealrc, error) {
-	_, err := os.Stat(QsealrcFileName)
-	if os.IsNotExist(err) {
+	dir, found, err := walkDir()
+	if err != nil {
+		return nil, err
+	}
+	if !found {
 		return nil, fmt.Errorf("file %s does not exist", QsealrcFileName)
 	}
+
+	err = os.Chdir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("could not change directory to %s: %w", dir, err)
+	}
+
 	file, err := os.Open(QsealrcFileName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This allows to run qseal in any folder of your project, not only from the base directory.
The `init` command will also search parent directories and return an error, unless if passed the new `--ignore-parents (-i)` flag.